### PR TITLE
Android: force all dependency to use lower Java version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,10 +12,23 @@ buildscript {
     }
 }
 
+apply from: 'kotlin-jvm.gradle'
+
 allprojects {
     repositories {
         google()
         mavenCentral()
+    }
+    subprojects {
+        afterEvaluate { project ->
+            if (project.hasProperty('android')) {
+                project.android {
+                    if (namespace == null) {
+                        namespace project.group
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/android/kotlin-jvm.gradle
+++ b/android/kotlin-jvm.gradle
@@ -1,0 +1,20 @@
+subprojects {
+    afterEvaluate { project ->
+        if (project.plugins.hasPlugin('kotlin-android')) {
+            project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+                kotlinOptions {
+                    jvmTarget = '17'
+                }
+            }
+        }
+        
+        if (project.hasProperty('android')) {
+            project.android {
+                compileOptions {
+                    sourceCompatibility JavaVersion.VERSION_17
+                    targetCompatibility JavaVersion.VERSION_17
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolve this issue:
`
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':screenshot_callback:compileDebugKotlin'.
> Inconsistent JVM-target compatibility detected for tasks 'compileDebugJavaWithJavac' (1.8) and 'compileDebugKotlin' (17).
 Consider using JVM Toolchain: https://kotl.in/gradle/jvm/toolchain
 Learn more about JVM-target validation: https://kotl.in/gradle/jvm/target-validation
* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org/.
BUILD FAILED in 16s
Error: Gradle task assembleStagingDebug failed with exit code 1
`